### PR TITLE
cf_workersを利用した実装

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,15 +1,18 @@
 import 'dart:js_interop';
 
-import 'package:http/http.dart' as http;
+// JSResponseを使いたいので cf_workers を入れています．
+import 'package:cf_workers/src/http.dart';
 
 @JS()
-external void responseMessage(JSString message);
+external JSPromise<JSResponse> fetch(JSString url);
+
+// Dartの結果をresultを通して渡しています
+@JS('__js.result')
+external void result(JSResponse response);
 
 void main(List<String> arguments) async {
-  // 普通にHTTP Packageでできる...?
-  // ref: https://github.com/vasilev/HTTP-request-from-inside-WASM?tab=readme-ov-file#dart
-  final resp = await http.get(Uri.parse('https://httpbin.org/anything'));
-  print(resp.body);
-
-  responseMessage(resp.body.toJS);
+  final JSResponse resp =
+      await fetch('https://httpbin.org/anything'.toJS).toDart;
+  print(resp);
+  result(resp);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: f6dbf021f4b214d85c79822912c5fcd142a2c4869f01222ad371bc51f9f1c356
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "74.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: f7e8caf82f2d3190881d81012606effdf8a38e6c1ab9e30947149733065f817c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.0"
   args:
     dependency: transitive
     description:
@@ -202,10 +202,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,19 @@ export default {
   async fetch(
     request: Request,
     env: {},
-    ctx: ExecutionContext
+    ctx: ExecutionContext,
   ): Promise<Response> {
     let responseMessage: string;
-    (globalThis as any).responseMessage = (message: string) => {
-      responseMessage = message;
-    };
+    const instance = await instantiate(mod, Promise.resolve({}));
 
-    invoke(await instantiate(mod, async () => ({})));
-
-    return new Response(responseMessage!);
+    return new Promise((resolve) => {
+      // Dart側で発生したPromiseをinvokeで受け持つことが現状できないので，このような作りにしています．
+      invoke(instance);
+      (globalThis as any).__js = {
+        result(response: Response) {
+          resolve(response);
+        },
+      };
+    });
   },
 };


### PR DESCRIPTION
こんな感じのコードで一旦動きます．

`package:http`は現状Wasmはサポートしていないようです．
`package:fetch_client`がそのあたりサポートしていてなんだか良さそうだったんですが，pnpm devで実行するとエラーが出るので何かしら実装ミスがありそう．

`package:cf_workers`の`JSResponse`という型定義を使うためにcf_workersを入れてみていますが，この書き方だと`JSObject`でも問題ないですね．

### `cf_workers`に`fetch`関数追加してみました．
https://pub.dev/packages/cf_workers/example

e.g.
https://github.com/a-skua/cf_workers.dart/blob/ce3b36a83af7a254190e7425918eb533ae205d4e/example/example.dart#L1-L11